### PR TITLE
Fix flaky test: bundles/core,com.adobe.cq.wcm.core.components.internal.models.v1.contentfragment.ContentFragmentImplTest#structuredVariation

### DIFF
--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/Utils.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/Utils.java
@@ -85,6 +85,7 @@ public class Utils {
                 if (outputMap.get(key) instanceof JsonArray) {
                     JsonArray expectedArray = (JsonArray) expectedMap.get(key);
                     JsonArray outputArray = (JsonArray) outputMap.get(key);
+                    assertEquals(expectedArray.size(), outputArray.size());
                     for (Object o : expectedArray) {
                         assertEquals(outputArray.contains(o), true);
                     }

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/Utils.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/Utils.java
@@ -28,6 +28,7 @@ import javax.json.Json;
 import javax.json.JsonObject;
 import javax.json.JsonReader;
 import javax.json.JsonStructure;
+import javax.json.JsonArray;
 
 import com.adobe.cq.wcm.core.components.models.datalayer.ComponentData;
 import org.apache.commons.io.FilenameUtils;
@@ -75,8 +76,24 @@ public class Utils {
         JsonReader outputReader = Json.createReader(IOUtils.toInputStream(writer.toString(), StandardCharsets.UTF_8));
         InputStream is = Utils.class.getResourceAsStream(expectedJsonResource);
         if (is != null) {
+
             JsonReader expectedReader = Json.createReader(is);
-            assertEquals(expectedReader.read(), outputReader.read());
+            JsonObject expectedMap = expectedReader.readObject();
+            JsonObject outputMap = outputReader.readObject();
+
+            for (Object key: outputMap.keySet()) {
+                if (outputMap.get(key) instanceof JsonArray) {
+                    JsonArray expectedArray = (JsonArray) expectedMap.get(key);
+                    JsonArray outputArray = (JsonArray) outputMap.get(key);
+                    for (Object o : expectedArray) {
+                        assertEquals(outputArray.contains(o), true);
+                    }
+                }
+                else {
+                    assertEquals(expectedMap.get(key), outputMap.get(key));
+                }
+            }
+            
         } else {
             fail("Unable to find test file " + expectedJsonResource + ".");
         }

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/contentfragment/ContentFragmentImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/contentfragment/ContentFragmentImplTest.java
@@ -20,6 +20,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Collections;
+import java.util.Arrays;
+import java.util.Comparator;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.sling.api.resource.Resource;
@@ -305,9 +308,24 @@ class ContentFragmentImplTest extends AbstractContentFragmentTest<ContentFragmen
         assertNotNull(elementsMap);
         List<DAMContentFragment.DAMContentElement> elements = new ArrayList<>(elementsMap.values());
         assertEquals(expectedElements.length, elements.size(), "Content fragment has wrong number of elements");
+
+        MockElement[] temp = new MockElement[expectedElements.length];
         for (int i = 0; i < expectedElements.length; i++) {
-            DAMContentFragment.DAMContentElement element = elements.get(i);
-            MockElement expected = expectedElements[i];
+            temp[i] = expectedElements[i];
+        }
+        List<MockElement> new_list = Arrays.asList(temp);
+        Collections.sort(new_list);
+
+        List<DAMContentFragment.DAMContentElement> new_elements = new ArrayList<DAMContentFragment.DAMContentElement>();
+        for (int i = 0; i < elements.size(); i++) {
+            new_elements.add(elements.get(i));
+        }
+        new_elements.sort(Comparator.comparing(DAMContentFragment.DAMContentElement::getName));
+        
+        
+        for (int i = 0; i < expectedElements.length; i++) {
+            DAMContentFragment.DAMContentElement element = new_elements.get(i);
+            MockElement expected = new_list.get(i);
             assertEquals(expected.name, element.getName(), "Element has wrong name");
             assertEquals(expected.title, element.getTitle(), "Element has wrong title");
             String contentType = expected.contentType;

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/contentfragment/MockElement.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/contentfragment/MockElement.java
@@ -18,7 +18,7 @@ package com.adobe.cq.wcm.core.components.internal.models.v1.contentfragment;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
-public class MockElement {
+public class MockElement implements Comparable<MockElement> {
 
     public String name;
     public String title;
@@ -57,5 +57,10 @@ public class MockElement {
     public void addVariation(String name, String title, String contentType, String value, boolean isMultiline,
                              String htmlValue) {
         variations.put(name, new MockVariation(name, title, contentType, value, isMultiline, htmlValue));
+    }
+    
+    @Override
+    public int compareTo(MockElement p) {
+        return this.name.compareTo(p.name);
     }
 }


### PR DESCRIPTION
bundles/core,com.adobe.cq.wcm.core.components.internal.models.v1.contentfragment.ContentFragmentImplTest#structuredVariation

<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/adobe/aem-core-wcm-components/blob/master/CONTRIBUTING.md

IMPORTANT: Please base your pull request on the **development** branch! The maintainers will cherry-pick the change to
 master after it's successfully integrated and tested.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/)
followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

The cause of the flakiness of the test has two parts. 

The first part is in `ContentFragmentImplTest.java: void assertContentFragment()` where it loops a Map simply by getting Map.values(). I fixed this by sorting the values array and ensuring elements are compared in the same order.

The second part is in `Utils.java: voidtestJSONExport()` where it asserts two nested Json files just by comparing their toString() values. I fixed this by taking each key from the Json files and comparing the value in two Json files with the same key.

After applying the modification stated above, the tests can now pass NonDex tests, and the modification may fix more tests other than the one stated at the beginning. The test case can now generate stable results regardless of different implementations in Map and JsonObjects.

<!-- Describe your changes below in as much detail as possible -->
